### PR TITLE
Add user_rf_pre_init() function to fix build error with SDK-1.1.0

### DIFF
--- a/user/user_main.c
+++ b/user/user_main.c
@@ -92,6 +92,9 @@ void mqttDataCb(uint32_t *args, const char* topic, uint32_t topic_len, const cha
 	os_free(dataBuf);
 }
 
+void user_rf_pre_init(void)
+{
+}
 
 void user_init(void)
 {


### PR DESCRIPTION
This patch fixes below build error with SDK-1.1.0:
esp-open-sdk/sdk/lib/libmain.a(app_main.o): In function `user_uart_wait_tx_fifo_empty':
(.irom0.text+0x34c): undefined reference to `user_rf_pre_init'

According to esp_iot_sdk_v1.1.0_15_05_26 Release Note:
user_rf_pre_init has to be added in user_main.c, user can call
system_phy_set_rfoption to set configuration of RF in it.