### PR TITLE
Revert "Add user_rf_pre_init() function to fix build error with SDK-1…

### DIFF
--- a/user/user_main.c
+++ b/user/user_main.c
@@ -92,9 +92,6 @@ void mqttDataCb(uint32_t *args, const char* topic, uint32_t topic_len, const cha
 	os_free(dataBuf);
 }
 
-void user_rf_pre_init(void)
-{
-}
 
 void user_init(void)
 {


### PR DESCRIPTION
….1.0"

This reverts commit 5ff97669081782aa3acfba012372ec487c3fbe03.

The esp-onen-sdk adds the fix for force-requiring user_rf_pre_init() [1].
So we need to drop the user_rf_pre_init function in user_main.c to prevent
multiple definition of `user_rf_pre_init' error.

[1] https://github.com/pfalcon/esp-open-sdk/commit/4e4590de89bc1524f6b7e7c35744325f9dc2e27b