### PR TITLE
Adding crypto modul for esp_mqtt to work with SDK 1.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: cpp
 before_install:
+- sudo apt-get -qq update
 - sudo apt-get install -y python-serial srecord
 install:
 - wget https://github.com/GeorgeHahn/nodemcu-firmware/raw/travis/tools/esp-open-sdk.tar.gz -O tools/esp-open-sdk.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ install:
 - wget https://github.com/GeorgeHahn/nodemcu-firmware/raw/travis/tools/esp-open-sdk.tar.gz -O tools/esp-open-sdk.tar.gz
 - tar -zxvf tools/esp-open-sdk.tar.gz
 - export PATH=$PATH:$PWD/esp-open-sdk/sdk:$PWD/esp-open-sdk/xtensa-lx106-elf/bin
-- wget http://bbs.espressif.com/download/file.php?id=189 -O tools/esp_iot_sdk_v0.9.5_15_01_23.zip
-- unzip tools/esp_iot_sdk_v0.9.5_15_01_23.zip
+- wget http://bbs.espressif.com/download/file.php?id=1046 -O tools/esp_iot_sdk_v1.5.1.zip
+- unzip tools/esp_iot_sdk_v1.5.1.zip
 script:
-- make all SDK_BASE="$PWD/esp_iot_sdk_v0.9.5"
+- make all SDK_BASE="$PWD/esp_iot_sdk_v1.5.1"
 - cd firmware/
 - file_name="esp_mqtt_v${TRAVIS_TAG}.${TRAVIS_BUILD_NUMBER}.bin"
 - srec_cat -output ${file_name} -binary 0x00000.bin -binary -fill 0xff 0x00000 0x40000 0x40000.bin -binary -offset 0x40000

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ MODULES		= driver mqtt user modules
 EXTRA_INCDIR    = include $(SDK_BASE)/../include
 
 # libraries used in this project, mainly provided by the SDK
-LIBS		= c gcc hal phy pp net80211 lwip wpa main ssl
+LIBS		= c gcc hal phy pp net80211 lwip wpa main ssl crypto
 
 # compiler flags using during compilation of source files
 CFLAGS		= -Os -Wpointer-arith -Wundef -Werror -Wl,-EL -fno-inline-functions -nostdlib -mlongcalls -mtext-section-literals  -D__ets__ -DICACHE_FLASH


### PR DESCRIPTION
The compilation failed for me with the newest SDK 1.5.0.
Appaerently the module "crypto" was missing - added this and the project compiles fine now.

Signed-off-by: Simon Egli <simon.egli@bbv.ch>