### PR TITLE
mqtt_get_publish_data() should always return len=0 if data=NULL.

### DIFF
--- a/mqtt/mqtt_msg.c
+++ b/mqtt/mqtt_msg.c
@@ -185,8 +185,10 @@ const char* ICACHE_FLASH_ATTR mqtt_get_publish_data(uint8_t* buffer, uint16_t* l
   int i;
   int totlen = 0;
   int topiclen;
+  int blength = *length;
+  *length = 0;
 
-  for(i = 1; i < *length; ++i)
+  for(i = 1; i < blength; ++i)
   {
     totlen += (buffer[i] & 0x7f) << (7 * (i - 1));
     if((buffer[i] & 0x80) == 0)
@@ -197,20 +199,19 @@ const char* ICACHE_FLASH_ATTR mqtt_get_publish_data(uint8_t* buffer, uint16_t* l
   }
   totlen += i;
 
-  if(i + 2 >= *length)
+  if(i + 2 >= blength)
     return NULL;
   topiclen = buffer[i++] << 8;
   topiclen |= buffer[i++];
 
-  if(i + topiclen >= *length){
-	*length = 0;
+  if(i + topiclen >= blength)
     return NULL;
-  }
+
   i += topiclen;
 
   if(mqtt_get_qos(buffer) > 0)
   {
-    if(i + 2 >= *length)
+    if(i + 2 >= blength)
       return NULL;
     i += 2;
   }
@@ -218,10 +219,10 @@ const char* ICACHE_FLASH_ATTR mqtt_get_publish_data(uint8_t* buffer, uint16_t* l
   if(totlen < i)
     return NULL;
 
-  if(totlen <= *length)
+  if(totlen <= blength)
     *length = totlen - i;
   else
-    *length = *length - i;
+    *length = blength - i;
   return (const char*)(buffer + i);
 }
 


### PR DESCRIPTION
In case of qos>0 mqtt_get_publish_data might return data=NULL but
leave len=buffer_len (!= 0). Doing a memcpy(user_buffer, data, len)
with such a len cause a segfault. This patch always set len=0 when
data=NULL.