### PR TITLE
Delete existing connection before connecting

### DIFF
--- a/mqtt/mqtt.c
+++ b/mqtt/mqtt.c
@@ -751,10 +751,11 @@ MQTT_InitLWT(MQTT_Client *mqttClient, uint8_t* will_topic, uint8_t* will_msg, ui
 void ICACHE_FLASH_ATTR
 MQTT_Connect(MQTT_Client *mqttClient)
 {
-	// Do not connect if this client is already connected otherwise the
-	// two espconn connections may interfere causing unexpected behaviour.
 	if (mqttClient->pCon) {
-		return;
+		// Clean up the old connection forcefully - using MQTT_Disconnect
+		// does not actually release the old connection until the
+		// disconnection callback is invoked.
+		mqtt_tcpclient_delete(mqttClient);
 	}
 	mqttClient->pCon = (struct espconn *)os_zalloc(sizeof(struct espconn));
 	mqttClient->pCon->type = ESPCONN_TCP;


### PR DESCRIPTION
If the current connection is terminated unexpectedly (e.g. because the
WiFi connection is dropped) the disconnect callback is not called. This
means that reestablishing the existing connection is not possible any
more.

Avoid this issue by forcefully removing the existing connection before
initiating the reconnection. Calling MQTT_Disconnect and waiting for
the disconnection callback should still be performed for intentional
disconnections.

Fixes #96