### PR TITLE
Sanitize config strings

### DIFF
--- a/modules/config.c
+++ b/modules/config.c
@@ -87,15 +87,16 @@ CFG_Load()
 
 		sysCfg.cfg_holder = CFG_HOLDER;
 
-		os_sprintf(sysCfg.sta_ssid, "%s", STA_SSID);
-		os_sprintf(sysCfg.sta_pwd, "%s", STA_PASS);
+		os_sprintf(sysCfg.device_id, MQTT_CLIENT_ID, system_get_chip_id());
+		sysCfg.device_id[sizeof(sysCfg.device_id) - 1] = '\0';
+		os_strncpy(sysCfg.sta_ssid, STA_SSID, sizeof(sysCfg.sta_ssid) - 1);
+		os_strncpy(sysCfg.sta_pwd, STA_PASS, sizeof(sysCfg.sta_pwd) - 1);
 		sysCfg.sta_type = STA_TYPE;
 
-		os_sprintf(sysCfg.device_id, MQTT_CLIENT_ID, system_get_chip_id());
-		os_sprintf(sysCfg.mqtt_host, "%s", MQTT_HOST);
+		os_strncpy(sysCfg.mqtt_host, MQTT_HOST, sizeof(sysCfg.mqtt_host) - 1);
 		sysCfg.mqtt_port = MQTT_PORT;
-		os_sprintf(sysCfg.mqtt_user, "%s", MQTT_USER);
-		os_sprintf(sysCfg.mqtt_pass, "%s", MQTT_PASS);
+		os_strncpy(sysCfg.mqtt_user, MQTT_USER, sizeof(sysCfg.mqtt_user) - 1);
+		os_strncpy(sysCfg.mqtt_pass, MQTT_PASS, sizeof(sysCfg.mqtt_pass) - 1);
 
 		sysCfg.security = DEFAULT_SECURITY;	/* default non ssl */
 

--- a/modules/include/config.h
+++ b/modules/include/config.h
@@ -34,7 +34,7 @@
 #include "user_config.h"
 typedef struct{
 	uint32_t cfg_holder;
-	uint8_t device_id[16];
+	uint8_t device_id[32];
 
 	uint8_t sta_ssid[64];
 	uint8_t sta_pwd[64];


### PR DESCRIPTION
Extend the device_id to 32 characters, and make sure all strings a null-terminated. This makes #108 a little bit less problematic.