### PR TITLE
add wrapper for un-subscribe, check user/pass for NULL

### DIFF
--- a/mqtt/include/mqtt.h
+++ b/mqtt/include/mqtt.h
@@ -140,7 +140,7 @@ void ICACHE_FLASH_ATTR MQTT_OnPublished(MQTT_Client *mqttClient, MqttCallback pu
 void ICACHE_FLASH_ATTR MQTT_OnTimeout(MQTT_Client *mqttClient, MqttCallback timeoutCb);
 void ICACHE_FLASH_ATTR MQTT_OnData(MQTT_Client *mqttClient, MqttDataCallback dataCb);
 BOOL ICACHE_FLASH_ATTR MQTT_Subscribe(MQTT_Client *client, char* topic, uint8_t qos);
-BOOL MQTT_UnSubscribe(MQTT_Client *client, char* topic);
+BOOL ICACHE_FLASH_ATTR MQTT_UnSubscribe(MQTT_Client *client, char* topic);
 void ICACHE_FLASH_ATTR MQTT_Connect(MQTT_Client *mqttClient);
 void ICACHE_FLASH_ATTR MQTT_Disconnect(MQTT_Client *mqttClient);
 BOOL ICACHE_FLASH_ATTR MQTT_Publish(MQTT_Client *client, const char* topic, const char* data, int data_length, int qos, int retain);

--- a/mqtt/include/mqtt.h
+++ b/mqtt/include/mqtt.h
@@ -140,6 +140,7 @@ void ICACHE_FLASH_ATTR MQTT_OnPublished(MQTT_Client *mqttClient, MqttCallback pu
 void ICACHE_FLASH_ATTR MQTT_OnTimeout(MQTT_Client *mqttClient, MqttCallback timeoutCb);
 void ICACHE_FLASH_ATTR MQTT_OnData(MQTT_Client *mqttClient, MqttDataCallback dataCb);
 BOOL ICACHE_FLASH_ATTR MQTT_Subscribe(MQTT_Client *client, char* topic, uint8_t qos);
+BOOL MQTT_UnSubscribe(MQTT_Client *client, char* topic);
 void ICACHE_FLASH_ATTR MQTT_Connect(MQTT_Client *mqttClient);
 void ICACHE_FLASH_ATTR MQTT_Disconnect(MQTT_Client *mqttClient);
 BOOL ICACHE_FLASH_ATTR MQTT_Publish(MQTT_Client *client, const char* topic, const char* data, int data_length, int qos, int retain);

--- a/mqtt/mqtt.c
+++ b/mqtt/mqtt.c
@@ -724,15 +724,21 @@ MQTT_InitClient(MQTT_Client *mqttClient, uint8_t* client_id, uint8_t* client_use
 	os_strcpy(mqttClient->connect_info.client_id, client_id);
 	mqttClient->connect_info.client_id[temp] = 0;
 
-	temp = os_strlen(client_user);
-	mqttClient->connect_info.username = (uint8_t*)os_zalloc(temp + 1);
-	os_strcpy(mqttClient->connect_info.username, client_user);
-	mqttClient->connect_info.username[temp] = 0;
+	if (client_user)
+	{
+		temp = os_strlen(client_user);
+		mqttClient->connect_info.username = (uint8_t*)os_zalloc(temp + 1);
+		os_strcpy(mqttClient->connect_info.username, client_user);
+		mqttClient->connect_info.username[temp] = 0;
+	}
 
-	temp = os_strlen(client_pass);
-	mqttClient->connect_info.password = (uint8_t*)os_zalloc(temp + 1);
-	os_strcpy(mqttClient->connect_info.password, client_pass);
-	mqttClient->connect_info.password[temp] = 0;
+	if (client_pass)
+	{
+		temp = os_strlen(client_pass);
+		mqttClient->connect_info.password = (uint8_t*)os_zalloc(temp + 1);
+		os_strcpy(mqttClient->connect_info.password, client_pass);
+		mqttClient->connect_info.password[temp] = 0;
+	}
 
 
 	mqttClient->connect_info.keepalive = keepAliveTime;


### PR DESCRIPTION
Adds missing wrapper for posting an un-subscribe message. I'm not 100% sure this is implemented correctly but have tested it and it works as expected. 

Also, check if user/pass are NULL in MQTT_InitClient as these are not explicitly required for MQTT operation.