### PR TITLE
Use proper type for keepalive

### DIFF
--- a/mqtt/include/mqtt_msg.h
+++ b/mqtt/include/mqtt_msg.h
@@ -100,7 +100,7 @@ typedef struct mqtt_connect_info
   char* password;
   char* will_topic;
   char* will_message;
-  int keepalive;
+  uint32_t keepalive;
   int will_qos;
   int will_retain;
   int clean_session;


### PR DESCRIPTION
Minor, but keepalive member in struct mqtt_connect_info is signed and gets compared with unsigned.