### PR TITLE
Compile to Library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,7 @@ CFLAGS		= -g			\
 						-Wpointer-arith		\
 						-Wundef			\
 						-Wl,-EL			\
+						-Wno-implicit-function-declaration \
 						-fno-inline-functions	\
 						-nostdlib       \
 						-mlongcalls	\


### PR DESCRIPTION
to successfully build without adding declarations missing from the SDK