### PR TITLE
Put keepAliveTick in more sensible location

### DIFF
--- a/mqtt/mqtt.c
+++ b/mqtt/mqtt.c
@@ -745,16 +745,15 @@ MQTT_Task(os_event_t *e)
 
         client->sendTimeout = MQTT_SEND_TIMOUT;
         MQTT_INFO("MQTT: Sending, type: %d, id: %04X\r\n", client->mqtt_state.pending_msg_type, client->mqtt_state.pending_msg_id);
+        client->keepAliveTick = 0;
         if (client->security) {
 #ifdef MQTT_SSL_ENABLE
-          client->keepAliveTick = 0;
           espconn_secure_send(client->pCon, dataBuffer, dataLen);
 #else
           MQTT_INFO("TCP: Do not support SSL\r\n");
 #endif
         }
         else {
-          client->keepAliveTick = 0;
           espconn_send(client->pCon, dataBuffer, dataLen);
         }
 

--- a/mqtt/mqtt.c
+++ b/mqtt/mqtt.c
@@ -297,7 +297,6 @@ mqtt_tcpclient_recv(void *arg, char *pdata, unsigned short len)
   struct espconn *pCon = (struct espconn*)arg;
   MQTT_Client *client = (MQTT_Client *)pCon->reverse;
 
-  client->keepAliveTick = 0;
 READPACKET:
   MQTT_INFO("TCP: data received %d bytes\r\n", len);
   // MQTT_INFO("STATE: %d\r\n", client->connState);
@@ -748,12 +747,14 @@ MQTT_Task(os_event_t *e)
         MQTT_INFO("MQTT: Sending, type: %d, id: %04X\r\n", client->mqtt_state.pending_msg_type, client->mqtt_state.pending_msg_id);
         if (client->security) {
 #ifdef MQTT_SSL_ENABLE
+          client->keepAliveTick = 0;
           espconn_secure_send(client->pCon, dataBuffer, dataLen);
 #else
           MQTT_INFO("TCP: Do not support SSL\r\n");
 #endif
         }
         else {
+          client->keepAliveTick = 0;
           espconn_send(client->pCon, dataBuffer, dataLen);
         }
 


### PR DESCRIPTION
In short, keepAliveTick should not be reset every time a packet is received, since, for ex, a QoS 0 packet does not require an Ack. So depending on QoS levels used, this will cause the server to disconnect the client due to no control message soon enough. Likely related to #128.

Steps to recreate issue:
 - Set client keepalive to 20 seconds
 - dont publish anything for > 30 seconds
 - spam the device with something like snippit below:

```
#!/bin/bash
SPAM_DELAY=1;
while :
do
   mosquitto_pub -h hostname -t /test/topic -m 'test playload'
   sleep $SPAM_DELAY;
done
```